### PR TITLE
Remove pricing page navigation and add navbar to account

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -47,9 +47,6 @@ const Navbar = () => {
           <Link to="/how-it-works" className="text-gray-600 hover:text-primary transition-colors">
             How It Works
           </Link>
-          <Link to="/pricing" className="text-gray-600 hover:text-primary transition-colors">
-            Pricing
-          </Link>
           <Link to="/faq" className="text-gray-600 hover:text-primary transition-colors">
             FAQ
           </Link>
@@ -120,13 +117,6 @@ const Navbar = () => {
                 onClick={() => setIsOpen(false)}
               >
                 How It Works
-              </Link>
-              <Link
-                to="/pricing"
-                className="text-lg font-medium"
-                onClick={() => setIsOpen(false)}
-              >
-                Pricing
               </Link>
               <Link
                 to="/faq"

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -18,6 +18,8 @@ import { supabaseClient } from "@/lib/supabase";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
 
 const Account = () => {
   const { user, signOut, isLoading } = useAuth();
@@ -92,10 +94,14 @@ const Account = () => {
   // Show loading state while authentication is being checked
   if (isLoading) {
     return (
-      <div className="container py-10">
-        <div className="flex justify-center items-center min-h-[300px]">
-          <div className="animate-pulse text-xl">Loading...</div>
-        </div>
+      <div className="flex flex-col min-h-screen">
+        <Navbar />
+        <main className="container py-10 flex-grow">
+          <div className="flex justify-center items-center min-h-[300px]">
+            <div className="animate-pulse text-xl">Loading...</div>
+          </div>
+        </main>
+        <Footer />
       </div>
     );
   }
@@ -103,23 +109,29 @@ const Account = () => {
   // Show login prompt if user is not authenticated
   if (!user) {
     return (
-      <div className="container py-10">
-        <h1 className="text-3xl font-bold mb-8">Your Account</h1>
-        <LoginPrompt />
+      <div className="flex flex-col min-h-screen">
+        <Navbar />
+        <main className="container py-10 flex-grow">
+          <h1 className="text-3xl font-bold mb-8">Your Account</h1>
+          <LoginPrompt />
+        </main>
+        <Footer />
       </div>
     );
   }
 
   return (
-    <div className="container py-10">
-      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8">
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="container py-10 flex-grow">
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8">
         <h1 className="text-3xl font-bold">Your Account</h1>
         <Button variant="outline" onClick={signOut} className="mt-4 sm:mt-0">
           Sign Out
         </Button>
-      </div>
+        </div>
 
-      <Tabs defaultValue="drafts" className="w-full">
+        <Tabs defaultValue="drafts" className="w-full">
         <TabsList className="grid w-full grid-cols-4 mb-8">
           <TabsTrigger value="drafts" className="flex gap-2 items-center">
             <FileText className="h-4 w-4" />
@@ -243,6 +255,8 @@ const Account = () => {
           </Card>
         </TabsContent>
       </Tabs>
+      </main>
+      <Footer />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove Pricing links from `Navbar`
- add `Navbar` and `Footer` to the Account page so users can navigate back to the site

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `node tests/renderStory.test.mjs` *(fails: Cannot find module 'dist/lib/renderStory.js')*