### PR TITLE
Add dummy blog articles fallback

### DIFF
--- a/src/lib/dummyBlogPosts.ts
+++ b/src/lib/dummyBlogPosts.ts
@@ -1,0 +1,27 @@
+export interface BlogPost {
+  id: string;
+  title: string;
+  content: string;
+  created_at: string;
+}
+
+export const DUMMY_BLOG_POSTS: BlogPost[] = [
+  {
+    id: 'welcome-to-the-blog',
+    title: 'Welcome to Our Blog',
+    content: `<p>Thank you for visiting our blog. Here we share updates and tips about donor conception stories and creating personalized books for your family.</p>`,
+    created_at: '2024-01-01T12:00:00Z',
+  },
+  {
+    id: 'why-share-your-story',
+    title: "Why Share Your Family's Story?",
+    content: `<p>Sharing your family's donor conception journey helps your child understand their origins and fosters openness. We make that easier with customizable books.</p>`,
+    created_at: '2024-02-01T12:00:00Z',
+  },
+  {
+    id: 'customization-tips',
+    title: 'Customization Tips',
+    content: `<p>Learn how to personalize characters and text in our books to match your family's unique look and story.</p>`,
+    created_at: '2024-03-01T12:00:00Z',
+  },
+];

--- a/src/pages/BlogHome.tsx
+++ b/src/pages/BlogHome.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { supabaseClient } from "@/lib/supabase";
+import { DUMMY_BLOG_POSTS } from "@/lib/dummyBlogPosts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { format } from "date-fns";
 
@@ -22,7 +23,17 @@ const BlogHome = () => {
         .select("id, title, created_at")
         .eq("published", true)
         .order("created_at", { ascending: false });
-      setPosts(data || []);
+      if (data && data.length > 0) {
+        setPosts(data);
+      } else {
+        setPosts(
+          DUMMY_BLOG_POSTS.map(({ id, title, created_at }) => ({
+            id,
+            title,
+            created_at,
+          }))
+        );
+      }
     };
     fetchPosts();
   }, []);

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { supabaseClient } from "@/lib/supabase";
+import { DUMMY_BLOG_POSTS } from "@/lib/dummyBlogPosts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { format } from "date-fns";
 
@@ -25,12 +26,25 @@ const BlogPost = () => {
         .eq("id", postId)
         .eq("published", true)
         .maybeSingle();
-      setPost(data);
+      if (data) {
+        setPost(data);
+      } else {
+        const fallback = DUMMY_BLOG_POSTS.find((p) => p.id === postId);
+        if (fallback) setPost(fallback);
+      }
     };
     if (postId) fetchPost();
   }, [postId]);
 
-  if (!post) return null;
+  if (!post) {
+    return (
+      <div className="flex flex-col min-h-screen">
+        <Navbar />
+        <main className="container py-10 flex-grow">Post not found</main>
+        <Footer />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col min-h-screen">


### PR DESCRIPTION
## Summary
- add a dummy blog posts file
- show fallback posts on blog home
- show fallback post on blog post page when not found

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run build`
- `node tests/renderStory.test.mjs` *(fails: Cannot find module 'dist/lib/renderStory.js')*