### PR TITLE
Add family profiles

### DIFF
--- a/src/components/FamiliesList.tsx
+++ b/src/components/FamiliesList.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { supabaseClient } from "@/lib/supabase";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import FamilyStructureStep from "@/components/book-customization/FamilyStructureStep";
+import FamilyMembersStep from "@/components/book-customization/FamilyMembersStep";
+import { Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+type Family = {
+  id: string;
+  user_id: string;
+  name: string;
+  structure: string;
+  members: any[];
+};
+
+const FamiliesList = () => {
+  const { user } = useAuth();
+  const [families, setFamilies] = useState<Family[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [newFamily, setNewFamily] = useState<{ name: string; structure: string; members: any[] }>({
+    name: "",
+    structure: "",
+    members: [],
+  });
+
+  useEffect(() => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    const fetchFamilies = async () => {
+      try {
+        setLoading(true);
+        const { data, error } = await supabaseClient
+          .from("families")
+          .select("*")
+          .eq("user_id", user.id)
+          .order("created_at", { ascending: false });
+        if (error) throw error;
+        setFamilies(data || []);
+      } catch (err: any) {
+        console.error("Error loading families:", err);
+        toast.error("Failed to load families");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchFamilies();
+  }, [user]);
+
+  const saveFamily = async () => {
+    if (!user) return;
+    try {
+      setSaving(true);
+      const { data, error } = await supabaseClient
+        .from("families")
+        .insert({
+          name: newFamily.name || "My Family",
+          structure: newFamily.structure,
+          members: newFamily.members,
+          user_id: user.id,
+        })
+        .select()
+        .single();
+      if (error) throw error;
+      setFamilies([data, ...families]);
+      setNewFamily({ name: "", structure: "", members: [] });
+      toast.success("Family saved");
+    } catch (err: any) {
+      console.error("Error saving family:", err);
+      toast.error("Failed to save family");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteFamily = async (id: string) => {
+    if (!user) return;
+    if (!confirm("Delete this family?")) return;
+    try {
+      const { error } = await supabaseClient.from("families").delete().eq("id", id);
+      if (error) throw error;
+      setFamilies(families.filter((f) => f.id !== id));
+      toast.success("Family deleted");
+    } catch (err: any) {
+      console.error("Error deleting family:", err);
+      toast.error("Failed to delete family");
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="text-center py-6">
+        <p className="text-muted-foreground">Please sign in to manage your families.</p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <Card key={i} className="overflow-hidden">
+            <CardContent className="p-6">
+              <Skeleton className="h-6 w-3/4" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {families.map((family) => (
+        <Card key={family.id} className="overflow-hidden">
+          <CardHeader>
+            <CardTitle>{family.name}</CardTitle>
+            <CardDescription>{family.structure}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="list-disc pl-5 space-y-1">
+              {family.members.map((m: any, idx: number) => (
+                <li key={idx}>
+                  {(m.role === "Other" ? m.customRole : m.role) || "Member"}: {m.name}
+                  {m.pronouns ? ` (${m.pronouns})` : ""}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+          <CardFooter className="flex justify-end">
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-destructive hover:text-destructive"
+              onClick={() => deleteFamily(family.id)}
+            >
+              <Trash2 className="h-4 w-4 mr-1" /> Delete
+            </Button>
+          </CardFooter>
+        </Card>
+      ))}
+      <Card>
+        <CardHeader>
+          <CardTitle>Add New Family</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="family-name">Family Name</Label>
+            <Input
+              id="family-name"
+              value={newFamily.name}
+              onChange={(e) => setNewFamily({ ...newFamily, name: e.target.value })}
+            />
+          </div>
+          <FamilyStructureStep
+            value={newFamily.structure}
+            onChange={(value) => setNewFamily({ ...newFamily, structure: value, members: [] })}
+          />
+          {newFamily.structure && (
+            <FamilyMembersStep
+              familyStructure={newFamily.structure}
+              familyMembers={newFamily.members}
+              onChange={(members) => setNewFamily({ ...newFamily, members })}
+            />
+          )}
+        </CardContent>
+        <CardFooter>
+          <Button onClick={saveFamily} disabled={saving || !newFamily.structure}>
+            {saving ? "Saving..." : "Save Family"}
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+};
+
+export default FamiliesList;

--- a/src/components/book-customization/BookCustomizationFlow.tsx
+++ b/src/components/book-customization/BookCustomizationFlow.tsx
@@ -7,6 +7,8 @@ import ChildDetailsStep from "@/components/book-customization/ChildDetailsStep";
 import IllustrationStep from "@/components/book-customization/IllustrationStep";
 import ReviewStep from "@/components/book-customization/ReviewStep";
 import { ChevronRight, Save, ShoppingCart } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
 
 interface BookCustomizationFlowProps {
   bookData: any;
@@ -21,6 +23,8 @@ interface BookCustomizationFlowProps {
   handleBack: () => void;
   handleNext: () => void;
   template: any;
+  savedFamilies?: any[];
+  onLoadFamily?: (family: any) => void;
 }
 
 const BookCustomizationFlow: React.FC<BookCustomizationFlowProps> = ({
@@ -36,6 +40,8 @@ const BookCustomizationFlow: React.FC<BookCustomizationFlowProps> = ({
   handleBack,
   handleNext,
   template,
+  savedFamilies,
+  onLoadFamily,
 }) => {
   const handleUpdateField = (field: string, value: any) => {
     setBookData((prev: any) => ({
@@ -53,10 +59,34 @@ const BookCustomizationFlow: React.FC<BookCustomizationFlowProps> = ({
         {template && (
           <>
             {currentStep === 0 && (
-              <FamilyStructureStep
-                value={bookData.familyStructure}
-                onChange={(value) => handleUpdateField("familyStructure", value)}
-              />
+              <>
+                {savedFamilies && savedFamilies.length > 0 && (
+                  <div className="mb-6 max-w-sm">
+                    <Label htmlFor="saved-family">Use Saved Family</Label>
+                    <Select
+                      onValueChange={(val) => {
+                        const fam = savedFamilies.find((f) => f.id === val);
+                        if (fam && onLoadFamily) onLoadFamily(fam);
+                      }}
+                    >
+                      <SelectTrigger id="saved-family">
+                        <SelectValue placeholder="Choose a saved family" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {savedFamilies.map((f) => (
+                          <SelectItem key={f.id} value={f.id}>
+                            {f.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+                <FamilyStructureStep
+                  value={bookData.familyStructure}
+                  onChange={(value) => handleUpdateField("familyStructure", value)}
+                />
+              </>
             )}
             {currentStep === 1 && (
               <FamilyMembersStep

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -113,6 +113,36 @@ export type Database = {
         }
         Relationships: []
       }
+      families: {
+        Row: {
+          id: string
+          user_id: string
+          name: string
+          structure: string
+          members: Json
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          name: string
+          structure: string
+          members?: Json
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          name?: string
+          structure?: string
+          members?: Json
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       profiles: {
         Row: {
           avatar_url: string | null

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -58,6 +58,35 @@ export type Database = {
           published?: boolean
         }
       }
+      families: {
+        Row: {
+          id: string
+          user_id: string
+          name: string
+          structure: string
+          members: any
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          name: string
+          structure: string
+          members?: any
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          name?: string
+          structure?: string
+          members?: any
+          created_at?: string
+          updated_at?: string
+        }
+      }
       profiles: {
         Row: {
           id: string

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -11,9 +11,10 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { BookOpen, Settings, FileText, LogIn } from "lucide-react";
+import { BookOpen, Settings, FileText, LogIn, Users } from "lucide-react";
 import DraftsList from "@/components/DraftsList";
 import BlogDraftsList from "@/components/BlogDraftsList";
+import FamiliesList from "@/components/FamiliesList";
 import { useNavigate } from "react-router-dom";
 import { supabaseClient } from "@/lib/supabase";
 import { Input } from "@/components/ui/input";
@@ -136,7 +137,7 @@ const Account = () => {
         </div>
 
         <Tabs defaultValue="drafts" className="w-full">
-        <TabsList className={`grid w-full mb-8 ${isContributor ? 'grid-cols-5' : 'grid-cols-4'}`}>
+        <TabsList className={`grid w-full mb-8 ${isContributor ? 'grid-cols-6' : 'grid-cols-5'}`}>
           <TabsTrigger value="drafts" className="flex gap-2 items-center">
             <FileText className="h-4 w-4" />
             <span className="hidden sm:inline">Saved Drafts</span>
@@ -148,15 +149,19 @@ const Account = () => {
             <span className="sm:hidden">Books</span>
           </TabsTrigger>
           {isContributor && (
-            <TabsTrigger value="blog" className="flex gap-2 items-center">
-              <FileText className="h-4 w-4" />
-              <span>Blog</span>
-            </TabsTrigger>
-          )}
-          <TabsTrigger value="settings" className="flex gap-2 items-center">
-            <Settings className="h-4 w-4" />
-            <span>Settings</span>
+          <TabsTrigger value="blog" className="flex gap-2 items-center">
+            <FileText className="h-4 w-4" />
+            <span>Blog</span>
           </TabsTrigger>
+        )}
+        <TabsTrigger value="families" className="flex gap-2 items-center">
+          <Users className="h-4 w-4" />
+          <span>Families</span>
+        </TabsTrigger>
+        <TabsTrigger value="settings" className="flex gap-2 items-center">
+          <Settings className="h-4 w-4" />
+          <span>Settings</span>
+        </TabsTrigger>
           <TabsTrigger value="profile" className="flex gap-2 items-center">
             <Avatar className="h-4 w-4">
               <AvatarFallback>
@@ -218,6 +223,18 @@ const Account = () => {
             </Card>
           </TabsContent>
         )}
+
+        <TabsContent value="families">
+          <Card>
+            <CardHeader>
+              <CardTitle>Your Families</CardTitle>
+              <CardDescription>Save family details for quick book customization.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <FamiliesList />
+            </CardContent>
+          </Card>
+        </TabsContent>
 
         <TabsContent value="settings">
           <Card>

--- a/src/pages/CustomizeBook.tsx
+++ b/src/pages/CustomizeBook.tsx
@@ -22,6 +22,7 @@ const CustomizeBook = () => {
   const [filter, setFilter] = useState<Filter>({ donor_process: "", art_process: "", family_structure: "" });
   const [selectedStory, setSelectedStory] = useState<BookTemplate | null>(null);
   const { bookData, setBookData } = useBookData();
+  const [families, setFamilies] = useState<any[]>([]);
 
   const steps = [
     { label: "Family Structure", icon: <Users className="h-5 w-5" /> },
@@ -34,6 +35,18 @@ const CustomizeBook = () => {
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const bookId = queryParams.get("book");
+
+  useEffect(() => {
+    if (!user) return;
+    const fetchFamilies = async () => {
+      const { data } = await supabaseClient
+        .from("families")
+        .select("*")
+        .eq("user_id", user.id);
+      setFamilies(data || []);
+    };
+    fetchFamilies();
+  }, [user]);
 
   useEffect(() => {
     if (bookId && user) {
@@ -70,6 +83,15 @@ const CustomizeBook = () => {
     } else {
       navigate(-1);
     }
+  };
+
+  const handleLoadFamily = (family: any) => {
+    if (!family) return;
+    setBookData((prev: any) => ({
+      ...prev,
+      familyStructure: family.structure,
+      familyMembers: family.members,
+    }));
   };
 
   const { handleSave, handleAddToCart, handleBuyNow } = useBookActions({
@@ -139,6 +161,8 @@ const CustomizeBook = () => {
       handleBuyNow={handleBuyNow}
       handleBack={handleBack}
       handleNext={handleNext}
+      savedFamilies={families}
+      onLoadFamily={handleLoadFamily}
     />
   );
 };

--- a/src/pages/customize/CustomizeView.tsx
+++ b/src/pages/customize/CustomizeView.tsx
@@ -22,6 +22,8 @@ interface CustomizeViewProps {
   handleBuyNow: () => void;
   handleBack: () => void;
   handleNext: () => void;
+  savedFamilies?: any[];
+  onLoadFamily?: (family: any) => void;
 }
 
 const CustomizeView: React.FC<CustomizeViewProps> = ({
@@ -37,6 +39,8 @@ const CustomizeView: React.FC<CustomizeViewProps> = ({
   handleBuyNow,
   handleBack,
   handleNext,
+  savedFamilies,
+  onLoadFamily,
 }) => {
   const book = {
     title: `${template?.name || "Your Child"}’s Story — ${(template as any)?.family_structure || "Family"} Book` +
@@ -119,6 +123,8 @@ const CustomizeView: React.FC<CustomizeViewProps> = ({
               handleBuyNow={handleBuyNow}
               handleBack={handleBack}
               handleNext={handleNext}
+              savedFamilies={savedFamilies}
+              onLoadFamily={onLoadFamily}
               template={template}
             />
           </div>

--- a/supabase/migrations/20250522000000_add-families.sql
+++ b/supabase/migrations/20250522000000_add-families.sql
@@ -1,0 +1,23 @@
+create table public.families (
+    id uuid not null default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    name text not null,
+    structure text not null,
+    members jsonb not null default '[]'::jsonb,
+    created_at timestamp with time zone not null default now(),
+    updated_at timestamp with time zone not null default now()
+);
+
+alter table public.families enable row level security;
+
+alter table public.families add constraint families_pkey primary key (id);
+
+grant select, insert, update, delete on table public.families to anon;
+grant select, insert, update, delete on table public.families to authenticated;
+grant select, insert, update, delete on table public.families to service_role;
+
+create policy "User can manage own families" on public.families
+as permissive for all
+to public
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- enable storing family data in Supabase via a new `families` table
- expose `families` table in Supabase type helpers
- add families tab on account page with management UI
- fetch saved families during book customization
- allow selecting a saved family when starting customization

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm test` *(fails: Missing script)*