### PR TITLE
Enable family profile saving from book customization

### DIFF
--- a/src/components/book-customization/BookCustomizationFlow.tsx
+++ b/src/components/book-customization/BookCustomizationFlow.tsx
@@ -25,6 +25,7 @@ interface BookCustomizationFlowProps {
   template: any;
   savedFamilies?: any[];
   onLoadFamily?: (family: any) => void;
+  handleSaveFamily?: () => void;
 }
 
 const BookCustomizationFlow: React.FC<BookCustomizationFlowProps> = ({
@@ -42,6 +43,7 @@ const BookCustomizationFlow: React.FC<BookCustomizationFlowProps> = ({
   template,
   savedFamilies,
   onLoadFamily,
+  handleSaveFamily,
 }) => {
   const handleUpdateField = (field: string, value: any) => {
     setBookData((prev: any) => ({
@@ -145,6 +147,12 @@ const BookCustomizationFlow: React.FC<BookCustomizationFlowProps> = ({
             {currentStep === 0 ? "Cancel" : "Back"}
           </Button>
           <div className="space-x-3">
+            {currentStep === 1 && handleSaveFamily && (
+              <Button variant="outline" onClick={handleSaveFamily} disabled={saving}>
+                <Save className="h-4 w-4 mr-2" />
+                Save Family
+              </Button>
+            )}
             {currentStep === steps.length - 1 ? (
               <>
                 <Button

--- a/src/pages/customize/CustomizeView.tsx
+++ b/src/pages/customize/CustomizeView.tsx
@@ -24,6 +24,7 @@ interface CustomizeViewProps {
   handleNext: () => void;
   savedFamilies?: any[];
   onLoadFamily?: (family: any) => void;
+  handleSaveFamily?: () => void;
 }
 
 const CustomizeView: React.FC<CustomizeViewProps> = ({
@@ -41,6 +42,7 @@ const CustomizeView: React.FC<CustomizeViewProps> = ({
   handleNext,
   savedFamilies,
   onLoadFamily,
+  handleSaveFamily,
 }) => {
   const book = {
     title: `${template?.name || "Your Child"}’s Story — ${(template as any)?.family_structure || "Family"} Book` +
@@ -125,6 +127,7 @@ const CustomizeView: React.FC<CustomizeViewProps> = ({
               handleNext={handleNext}
               savedFamilies={savedFamilies}
               onLoadFamily={onLoadFamily}
+              handleSaveFamily={handleSaveFamily}
               template={template}
             />
           </div>


### PR DESCRIPTION
## Summary
- allow `BookCustomizationFlow` to save a family profile during customization
- track selected family in `CustomizeBook` and expose save handler
- pass the new handler through `CustomizeView`

## Testing
- `npm run build`
- `npx tsc src/lib/renderStory.ts --outDir dist/lib --module ES2020`
- `node tests/renderStory.test.mjs`
